### PR TITLE
Switch from unmaintained PyOxidizer to tried-and-true PyInstaller.

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -62,14 +62,17 @@ jobs:
         matrix:
           include:
             - os: ubuntu-latest
-              target: x86_64-unknown-linux-gnu
-              executable: mimeogram
+              platform-name: linux-x86_64
+              suffix: ''
             - os: windows-latest
-              target: x86_64-pc-windows-msvc
-              executable: mimeogram.exe
+              platform-name: windows-x86_64
+              suffix: '.exe'
+            - os: macos-13
+              platform-name: macos-x86_64
+              suffix: ''
             - os: macos-latest
-              target: x86_64-apple-darwin
-              executable: mimeogram
+              platform-name: macos-arm64
+              suffix: ''
       runs-on: ${{ matrix.os }}
       steps:
 
@@ -84,16 +87,32 @@ jobs:
           with:
             python-version: ${{ fromJSON(needs.initialize.outputs.python-versions)[0] }}
 
+        # - name: Install UPX (Linux)
+        #   if: runner.os == 'Linux'
+        #   run: sudo apt-get install -y upx
+
+        - name: Install UPX (macOS)
+          if: runner.os == 'macOS'
+          run: brew install upx
+
+        - name: Install UPX (Windows)
+          if: runner.os == 'Windows'
+          run: choco install upx
+
         - name: Create Executable
           run: |
-            hatch --env develop run pyoxidizer build --release --target-triple ${{ matrix.target }}
+            hatch --env develop run \
+              pyinstaller --name mimeogram-${{ matrix.platform-name }} \
+                --clean --onefile \
+                --add-data=pyproject.toml:. --add-data=data:data \
+                --distpath=.auxiliary/artifacts/pyinstaller-build \
+                sources/mimeogram/__main__.py
 
         - name: Save Executable
           uses: actions/upload-artifact@v4
           with:
-            name: mimeogram-${{ matrix.target }}
-            # TODO: Adjust path.
-            path: build/${{ matrix.target }}/release/install/${{ matrix.executable }}
+            name: mimeogram-${{ matrix.platform-name }}
+            path: .auxiliary/artifacts/pyinstaller-build/mimeogram-${{ matrix.platform-name }}${{ matrix.suffix }}
 
   publish-pypi:
     if: ${{ inputs.which-pypi == 'testpypi' || startsWith(github.ref, 'refs/tags/') }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__/
 bugs/
 build/
+dist/
+mimeogram.spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
   'hatchling',
+  # 'hatch-pyinstaller',
 ]
 build-backend = 'hatchling.build'
 
@@ -21,7 +22,6 @@ dependencies = [
   'gitignorefile',
   'httpx',
   'importlib-resources',
-  # 'importlib-resources @ git+https://github.com/emcd/importlib_resources@as-file-traversable',
   'patiencediff',
   'platformdirs',
   'pyperclip',
@@ -85,6 +85,23 @@ output = '.auxiliary/artifacts/coverage-pytest/coverage.xml'
 # https://hatch.pypa.io/latest/config/metadata/
 [tool.hatch.build]
 directory = '.auxiliary/artifacts/hatch-build'
+# [tool.hatch.build.targets.pyinstaller]
+# only-include = [ 'sources/mimeogram', 'data' ]
+# flags = [
+#   '--add-data=pyproject.toml:.',
+#   '--add-data=data:data',
+#   '--clean',
+#   # '--distpath=.auxiliary/artifacts/hatch-build',
+#   '--name=mimeogram',
+#   '--onefile',
+# ]
+# log-level = "WARN"
+# require-runtime-dependencies = true
+# scriptname = 'sources/mimeogram/__main__.py'
+# # zip = true
+# [tool.hatch.build.targets.pyinstaller.sources]
+# 'sources/mimeogram' = 'mimeogram'
+# 'data' = 'mimeogram/data'
 [tool.hatch.build.targets.sdist]
 only-include = [ 'sources/mimeogram', 'data' ]
 strict-naming = false
@@ -105,12 +122,11 @@ dependencies = [
   'furo',
   'hypothesis',
   'icecream',
-  'oxidized-importer',
   'packaging',
   'pre-commit',
+  'pyinstaller',
   'pylint',
   'pylint-per-file-ignores',
-  'pyoxidizer',
   'pyright',
   'pytest',
   'pytest-asyncio',
@@ -150,7 +166,14 @@ linters = [
      sources/mimeogram''',
 ]
 packagers = [
-  'hatch build',
+  '''hatch build''',
+  '''pyinstaller --name mimeogram \
+      --clean \
+      --onefile \
+      --add-data=pyproject.toml:. \
+      --add-data=data:data \
+      --distpath=.auxiliary/artifacts/pyinstaller-build \
+      sources/mimeogram/__main__.py''',
 ]
 testers = [
   'coverage erase',

--- a/sources/mimeogram/__main__.py
+++ b/sources/mimeogram/__main__.py
@@ -21,7 +21,8 @@
 ''' Entrypoint. '''
 
 
-from .cli import execute
+# Note: Use absolute import for PyInstaller happiness.
+from mimeogram.cli import execute
 
 
 if '__main__' == __name__: execute( )

--- a/tests/test_000_mimeogram/test_500_acquirers.py
+++ b/tests/test_000_mimeogram/test_500_acquirers.py
@@ -259,9 +259,9 @@ async def test_520_nontextual_mime( provide_tempdir, provide_auxdata ):
     acquirers = cache_import_module( f"{PACKAGE_NAME}.acquirers" )
     exceptions = cache_import_module( f"{PACKAGE_NAME}.exceptions" )
 
-    # Create a small binary file
     binary_path = provide_tempdir / "binary.bin"
-    binary_path.write_bytes( bytes( range( 256 ) ) )  # Create binary file directly
+    # Create a binary file with random-looking but consistent content
+    binary_path.write_bytes( bytes( [ 0xFF, 0x00 ] * 128 ) )
 
     try:
         with pytest.raises( exceptiongroup.ExceptionGroup ) as excinfo:
@@ -271,15 +271,15 @@ async def test_520_nontextual_mime( provide_tempdir, provide_auxdata ):
         assert len( excinfo.value.exceptions ) == 1
         # Check that it's the right type of exception
         assert isinstance(
-            excinfo.value.exceptions[0],
+            excinfo.value.exceptions[ 0 ],
             exceptions.TextualMimetypeInvalidity )
         # Verify the error message includes path and mimetype
-        err_msg = str( excinfo.value.exceptions[0] )
+        err_msg = str( excinfo.value.exceptions[ 0 ] )
         assert str( binary_path ) in err_msg
         assert 'application/octet-stream' in err_msg
     finally:
-        if binary_path.exists():
-            binary_path.unlink()
+        if binary_path.exists( ):
+            binary_path.unlink( )
 
 
 # HTTP Tests


### PR DESCRIPTION
(Coauthor: Anthropic claude-3-5-sonnet)

Newer versions of Python not supported by some PyOxidizer components.
Can consider another try with PyOxidizer once it is actively maintained
by someone again: https://github.com/indygreg/PyOxidizer/issues/751
(The PyO3 or Astral.sh folks would seem to be logical candidates.)

Also:

* Tests: acquirers: Fix flaky test where byte pattern is interpreted as
  different MIME type depending on underlying 'libmagic' release. (Test
  passes on Ubuntu 20.04, but fails on Ubuntu 24.04.)