### PR TITLE
Update mimeogram to latest detextive package

### DIFF
--- a/.auxiliary/notes/detextive-bugs.md
+++ b/.auxiliary/notes/detextive-bugs.md
@@ -1,0 +1,17 @@
+# Detextive Issues
+
+## Binary Data Decoded as UTF-16-LE
+
+**Issue**: Detextive incorrectly decodes certain binary data as UTF-16-LE text.
+
+**Example**: A file containing alternating bytes `0xFF 0x00` repeated (i.e., `bytes([0xFF, 0x00] * 52)`) is successfully detected as having charset `utf-16-le` and decoded as text, producing a string of repeated `ÿ` characters.
+
+**Impact**: This causes binary files that should be rejected to be accepted as valid text files. While this is not a security risk for most cases (since the "decoded" content is gibberish), it means that mimeogram may accept files that are not genuinely textual.
+
+**Workaround**: Tests have been updated to use binary files with more recognizable headers (like PE executables with `MZ` magic bytes) that Detextive properly rejects. These files cause decode failures even when a charset is detected.
+
+**Status**: This is a limitation of charset detection algorithms in general - alternating binary patterns can appear to match certain multi-byte encodings like UTF-16. The issue should be reported to the Detextive project for potential improvement in validation heuristics.
+
+**Related Tests**:
+- `test_410_application_x_security`: Updated to check for truly dangerous files only
+- `test_520_nontextual_mime`: Updated to use PE executable header instead of simple binary pattern

--- a/.auxiliary/notes/issues.md
+++ b/.auxiliary/notes/issues.md
@@ -1,0 +1,78 @@
+# Known Issues
+
+## CLI Parser Failure with tyro
+
+**Discovered**: 2025-11-09 during Detextive 2.0 port verification
+
+**Status**: Pre-existing issue (exists before Detextive 2.0 port)
+
+**Severity**: Critical - CLI is completely non-functional
+
+### Description
+
+The mimeogram CLI fails to start with a tyro parser error:
+
+```
+AssertionError: UnsupportedStructTypeMessage(message="Empty hints for <slot wrapper '__init__' of '_io.TextIOWrapper' objects>!")
+```
+
+### Reproduction
+
+```bash
+hatch run mimeogram --help
+# or any other command: version, create, apply, provide-prompt
+```
+
+### Analysis
+
+The error originates from `tyro` attempting to parse the CLI structure and encountering a type that lacks proper type hints. The error occurs in:
+
+```
+File "/root/.local/share/hatch/env/.../tyro/_parsers.py", line 113, in from_callable_or_type
+    assert not isinstance(out, UnsupportedStructTypeMessage), out
+```
+
+The error mentions `_io.TextIOWrapper`, suggesting that somewhere in the command classes or their dependencies, there's a reference to stdin/stdout/stderr or file handles that tyro cannot introspect.
+
+### Timeline
+
+- **Commit 556db71** (Merge PR #9 - appcore cutover): Error present
+- **Commit fac1d9f** (Integrate detextive package): Error present
+- **Commit c1401a1** (Port to Detextive 2.0): Error present
+- **Commit 32a777f** (Fix linter errors): Error present
+
+This indicates the issue was introduced during the appcore refactor (PR #9), not by the Detextive 2.0 port.
+
+### Investigation Points
+
+1. **appcore type annotations**: The issue likely stems from how `appcore` types are exposed to tyro
+2. **CLI command definitions**: Check `cli.py`, `create.py`, `apply.py`, `prompt.py` for problematic type hints
+3. **TextIOWrapper references**: Search for uses of `sys.stdin`, `sys.stdout`, `sys.stderr` that may need explicit typing
+
+Confirmed uses in codebase:
+- `sources/mimeogram/apply.py:134`: `__.sys.stdin.isatty()`
+- `sources/mimeogram/apply.py:144`: `__.sys.stdin.read()`
+- `sources/mimeogram/interactions.py:76`: `__.sys.stdout.flush()`
+- `sources/mimeogram/display.py:60`: `__.sys.stdin.isatty()`
+
+### Suggested Fix
+
+Based on the user's suggestion: Switch to `emcd-appcore[cli]` which likely includes additional dependencies or type stubs that help tyro properly parse the CLI structure.
+
+### Impact
+
+- **Tests**: All 173 tests pass (tests don't exercise CLI parsing, they import modules directly)
+- **Linters**: Pass cleanly (ruff and pyright)
+- **Detextive integration**: Working correctly
+- **CLI functionality**: Completely broken - cannot run any commands
+
+### Workaround
+
+None currently available. The application can be used programmatically by importing modules directly, but the CLI is unusable.
+
+### Next Steps
+
+1. Try switching dependency from `emcd-appcore~=1.4` to `emcd-appcore[cli]~=1.4`
+2. If that doesn't resolve it, investigate the specific type annotation that tyro cannot parse
+3. Consider adding explicit type annotations to any stdin/stdout/stderr usage
+4. May need to report issue to `tyro` if it's a limitation in their type introspection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
   'absence~=1.1',
   'accretive~=4.1',
   'aiofiles',
-  'chardet',
-  'detextive~=1.0',
+  'detextive~=2.0',
   'dynadoc~=1.4',
   'emcd-appcore~=1.4',
   'exceptiongroup',
@@ -29,7 +28,6 @@ dependencies = [
   'httpx',
   'icecream-truck~=1.5',
   'patiencediff',
-  'puremagic',
   'pyperclip',
   'python-dotenv', # TODO: Remove after cutover to appcore.
   'readchar',

--- a/sources/mimeogram/acquirers.py
+++ b/sources/mimeogram/acquirers.py
@@ -78,13 +78,16 @@ async def _acquire_from_file( location: __.Path ) -> _parts.Part:
         async with _aiofiles.open( location, 'rb' ) as f: # pyright: ignore
             content_bytes = await f.read( )
     except Exception as exc: raise ContentAcquireFailure( location ) from exc
-    mimetype, charset = _detect_mimetype_and_charset( content_bytes, location )
+    mimetype, charset = __.detextive.infer_mimetype_charset(
+        content_bytes, location = str( location ) )
     if charset is None: raise ContentDecodeFailure( location, '???' )
     linesep = _parts.LineSeparators.detect_bytes( content_bytes )
     if linesep is None:
         _scribe.warning( f"No line separator detected in '{location}'." )
         linesep = _parts.LineSeparators( __.os.linesep )
-    try: content = content_bytes.decode( charset )
+    try:
+        content = __.detextive.decode(
+            content_bytes, location = str( location ) )
     except Exception as exc:
         raise ContentDecodeFailure( location, charset ) from exc
     _scribe.debug( f"Read file: {location}" )
@@ -105,21 +108,22 @@ async def _acquire_via_http(
         response = await client.get( url )
         response.raise_for_status( )
     except Exception as exc: raise ContentAcquireFailure( url ) from exc
-    mimetype = (
-        response.headers.get( 'content-type', 'application/octet-stream' )
-        .split( ';' )[ 0 ].strip( ) )
+    http_content_type = response.headers.get( 'content-type' )
     content_bytes = response.content
-    charset = response.encoding or _detect_charset( content_bytes )
+    mimetype, charset = __.detextive.infer_mimetype_charset(
+        content_bytes,
+        location = url,
+        http_content_type = http_content_type or __.absent )
     if charset is None: raise ContentDecodeFailure( url, '???' )
-    if not _is_textual_mimetype( mimetype ):
-        mimetype, _ = (
-            _detect_mimetype_and_charset(
-                content_bytes, url, charset = charset ) )
     linesep = _parts.LineSeparators.detect_bytes( content_bytes )
     if linesep is None:
         _scribe.warning( f"No line separator detected in '{url}'." )
         linesep = _parts.LineSeparators( __.os.linesep )
-    try: content = content_bytes.decode( charset )
+    try:
+        content = __.detextive.decode(
+            content_bytes,
+            location = url,
+            http_content_type = http_content_type or __.absent )
     except Exception as exc:
         raise ContentDecodeFailure( url, charset ) from exc
     _scribe.debug( f"Fetched URL: {url}" )
@@ -157,102 +161,6 @@ def _collect_directory_files(
     return paths
 
 
-def _detect_charset( content: bytes ) -> str | None:
-    from chardet import detect
-    charset = detect( content )[ 'encoding' ]
-    if charset is None: return charset
-    if charset.startswith( 'utf' ): return charset
-    match charset:
-        case 'ascii': return 'utf-8' # Assume superset.
-        case _: pass
-    # Shake out false positives, like 'MacRoman'.
-    try: content.decode( 'utf-8' )
-    except UnicodeDecodeError: return charset
-    return 'utf-8'
-
-
-def _detect_mimetype( content: bytes, location: str | __.Path ) -> str | None:
-    from mimetypes import guess_type
-    from puremagic import PureError, from_string # pyright: ignore
-    try: return from_string( content, mime = True )
-    except ( PureError, ValueError ):
-        return guess_type( str( location ) )[ 0 ]
-
-
-def _detect_mimetype_and_charset(
-    content: bytes,
-    location: str | __.Path, *,
-    mimetype: __.Absential[ str ] = __.absent,
-    charset: __.Absential[ str ] = __.absent,
-) -> tuple[ str, str | None ]:
-    from .exceptions import TextualMimetypeInvalidity
-    if __.is_absent( mimetype ):
-        mimetype_ = _detect_mimetype( content, location )
-    else: mimetype_ = mimetype
-    if __.is_absent( charset ): # noqa: SIM108
-        charset_ = _detect_charset( content )
-    else: charset_ = charset
-    if not mimetype_:
-        if charset_:
-            mimetype_ = 'text/plain'
-            _validate_mimetype_with_trial_decode(
-                content, location, mimetype_, charset_ )
-            return mimetype_, charset_
-        mimetype_ = 'application/octet-stream'
-    if _is_textual_mimetype( mimetype_ ):
-        return mimetype_, charset_
-    if charset_ is None:
-        raise TextualMimetypeInvalidity( location, mimetype_ )
-    _validate_mimetype_with_trial_decode(
-        content, location, mimetype_, charset_ )
-    return mimetype_, charset_
-
-
-def _is_reasonable_text_content( content: str ) -> bool:
-    ''' Checks if decoded content appears to be meaningful text. '''
-    if not content: return False
-    # Check for excessive repetition of single characters (likely binary)
-    if len( set( content ) ) == 1: return False
-    # Check for excessive control characters (excluding common whitespace)
-    common_whitespace = '\t\n\r'
-    ascii_control_limit = 32
-    control_chars = sum(
-        1 for c in content
-        if ord( c ) < ascii_control_limit and c not in common_whitespace )
-    if control_chars > len( content ) * 0.1: return False  # >10% control chars
-    # Check for reasonable printable character ratio
-    printable_chars = sum(
-        1 for c in content if c.isprintable( ) or c in common_whitespace )
-    return printable_chars >= len( content ) * 0.8  # >=80% printable
-
-
-# MIME types that are considered textual beyond those starting with 'text/'.
-_TEXTUAL_MIME_TYPES = frozenset( (
-    'application/json',
-    'application/xml',
-    'application/xhtml+xml',
-    'application/x-perl',
-    'application/x-python',
-    'application/x-php',
-    'application/x-ruby',
-    'application/x-shell',
-    'application/javascript',
-    'image/svg+xml',
-) )
-# MIME type suffixes that indicate textual content.
-_TEXTUAL_SUFFIXES = ( '+xml', '+json', '+yaml', '+toml' )
-def _is_textual_mimetype( mimetype: str ) -> bool:
-    ''' Checks if MIME type represents textual content. '''
-    _scribe.debug( f"MIME type: {mimetype}" )
-    if mimetype.startswith( ( 'text/', 'text/x-' ) ): return True
-    if mimetype in _TEXTUAL_MIME_TYPES: return True
-    if mimetype.endswith( _TEXTUAL_SUFFIXES ):
-        _scribe.debug(
-            f"MIME type '{mimetype}' accepted due to textual suffix." )
-        return True
-    return False
-
-
 def _produce_fs_tasks(
     location: str | __.Path, recursive: bool = False
 ) -> tuple[ __.cabc.Coroutine[ None, None, _parts.Part ], ...]:
@@ -277,19 +185,3 @@ def _produce_http_task(
         ) as client: return await _acquire_via_http( client, url )
 
     return _execute_session( )
-
-
-def _validate_mimetype_with_trial_decode(
-    content: bytes, location: str | __.Path, mimetype: str, charset: str
-) -> None:
-    ''' Validates charset fallback and returns appropriate MIME type. '''
-    from .exceptions import TextualMimetypeInvalidity
-    try: text = content.decode( charset )
-    except ( UnicodeDecodeError, LookupError ) as exc:
-        raise TextualMimetypeInvalidity( location, mimetype ) from exc
-    if _is_reasonable_text_content( text ):
-        _scribe.debug(
-            f"MIME type '{mimetype}' accepted after successful "
-            f"decode test with charset '{charset}' for '{location}'." )
-        return
-    raise TextualMimetypeInvalidity( location, mimetype )

--- a/sources/mimeogram/acquirers.py
+++ b/sources/mimeogram/acquirers.py
@@ -81,10 +81,10 @@ async def _acquire_from_file( location: __.Path ) -> _parts.Part:
     mimetype, charset = __.detextive.infer_mimetype_charset(
         content_bytes, location = str( location ) )
     if charset is None: raise ContentDecodeFailure( location, '???' )
-    linesep = _parts.LineSeparators.detect_bytes( content_bytes )
+    linesep = __.detextive.LineSeparators.detect_bytes( content_bytes )
     if linesep is None:
         _scribe.warning( f"No line separator detected in '{location}'." )
-        linesep = _parts.LineSeparators( __.os.linesep )
+        linesep = __.detextive.LineSeparators( __.os.linesep )
     try:
         content = __.detextive.decode(
             content_bytes, location = str( location ) )
@@ -115,10 +115,10 @@ async def _acquire_via_http(
         location = url,
         http_content_type = http_content_type or __.absent )
     if charset is None: raise ContentDecodeFailure( url, '???' )
-    linesep = _parts.LineSeparators.detect_bytes( content_bytes )
+    linesep = __.detextive.LineSeparators.detect_bytes( content_bytes )
     if linesep is None:
         _scribe.warning( f"No line separator detected in '{url}'." )
-        linesep = _parts.LineSeparators( __.os.linesep )
+        linesep = __.detextive.LineSeparators( __.os.linesep )
     try:
         content = __.detextive.decode(
             content_bytes,

--- a/sources/mimeogram/formatters.py
+++ b/sources/mimeogram/formatters.py
@@ -45,7 +45,7 @@ def format_mimeogram(
             location = 'mimeogram://message',
             mimetype = 'text/plain', # TODO? Markdown
             charset = 'utf-8',
-            linesep = _parts.LineSeparators.LF,
+            linesep = __.detextive.LineSeparators.LF,
             content = message )
         lines.append( format_part( message_part, boundary ) )
     for part in parts:

--- a/sources/mimeogram/parsers.py
+++ b/sources/mimeogram/parsers.py
@@ -109,17 +109,19 @@ def _parse_descriptor_and_content(
 
 
 _QUOTES = '"\''
-def _parse_mimetype( header: str ) -> tuple[ str, str, _parts.LineSeparators ]:
+def _parse_mimetype(
+    header: str
+) -> tuple[ str, str, __.detextive.LineSeparators ]:
     ''' Extracts MIME type and charset from Content-Type header. '''
     parts = [ p.strip( ) for p in header.split( ';' ) ]
     mimetype = parts[ 0 ]
     charset = 'utf-8'
-    linesep = _parts.LineSeparators.LF
+    linesep = __.detextive.LineSeparators.LF
     for part in parts[ 1: ]:
         if part.startswith( 'charset=' ):
             charset = part[ 8: ].strip( _QUOTES )
         if part.startswith( 'linesep=' ):
-            linesep = _parts.LineSeparators[
+            linesep = __.detextive.LineSeparators[
                 part[ 8: ].strip( _QUOTES ).upper( ) ]
     return mimetype, charset, linesep
 

--- a/sources/mimeogram/parts.py
+++ b/sources/mimeogram/parts.py
@@ -25,46 +25,7 @@ from . import __
 from . import fsprotect as _fsprotect
 
 
-class LineSeparators( __.enum.Enum ):
-    ''' Line separators for various platforms. '''
-
-    CR =    '\r'    # Classic MacOS
-    CRLF =  '\r\n'  # DOS/Windows
-    LF =    '\n'    # Unix/Linux
-
-    @classmethod
-    def detect_bytes(
-        selfclass, content: bytes, limit = 1024
-    ) -> "LineSeparators | None":
-        ''' Detects newline characters in bytes array. '''
-        sample = content[ : limit ]
-        found_cr = False
-        for byte in sample:
-            match byte:
-                case 0xd:
-                    if found_cr: return selfclass.CR
-                    found_cr = True
-                case 0xa: # linefeed
-                    if found_cr: return selfclass.CRLF
-                    return selfclass.LF
-                case _:
-                    if found_cr: return selfclass.CR
-        return None
-
-    @classmethod
-    def normalize_universal( selfclass, content: str ) -> str:
-        ''' Normalizes all varieties of newline characters in text. '''
-        return content.replace( '\r\n', '\r' ).replace( '\r', '\n' )
-
-    def nativize( self, content: str ) -> str:
-        ''' Nativizes specific variety newline characters in text. '''
-        if LineSeparators.LF is self: return content
-        return content.replace( '\n', self.value )
-
-    def normalize( self, content: str ) -> str:
-        ''' Normalizes specific variety newline characters in text. '''
-        if LineSeparators.LF is self: return content
-        return content.replace( self.value, '\n' )
+LineSeparators = __.detextive.LineSeparators
 
 
 class Resolutions( __.enum.Enum ):

--- a/sources/mimeogram/parts.py
+++ b/sources/mimeogram/parts.py
@@ -25,9 +25,6 @@ from . import __
 from . import fsprotect as _fsprotect
 
 
-LineSeparators = __.detextive.LineSeparators
-
-
 class Resolutions( __.enum.Enum ):
     ''' Available resolutions for each part. '''
 
@@ -40,7 +37,7 @@ class Part( __.immut.DataclassObject ):
     location: str # TODO? 'Url' class
     mimetype: str
     charset: str
-    linesep: "LineSeparators"
+    linesep: __.detextive.LineSeparators
     content: str
 
     # TODO? 'format' method

--- a/sources/mimeogram/updaters.py
+++ b/sources/mimeogram/updaters.py
@@ -182,7 +182,7 @@ async def _update_content_atomic(
     location: __.Path,
     content: str,
     charset: str = 'utf-8',
-    linesep: _parts.LineSeparators = _parts.LineSeparators.LF
+    linesep: __.detextive.LineSeparators = __.detextive.LineSeparators.LF
 ) -> None:
     ''' Updates file content atomically, if possible. '''
     import aiofiles.os as os # noqa: PLR0402

--- a/tests/test_000_mimeogram/test_110_parts.py
+++ b/tests/test_000_mimeogram/test_110_parts.py
@@ -26,17 +26,17 @@ from . import PACKAGE_NAME, cache_import_module
 
 def test_000_line_separators_enum( ):
     ''' Line separator enum values and attributes. '''
-    parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Check enum values
-    assert parts.LineSeparators.CR.value == '\r'
-    assert parts.LineSeparators.CRLF.value == '\r\n'
-    assert parts.LineSeparators.LF.value == '\n'
+    assert detextive.LineSeparators.CR.value == '\r'
+    assert detextive.LineSeparators.CRLF.value == '\r\n'
+    assert detextive.LineSeparators.LF.value == '\n'
 
 
 def test_010_line_separators_detection( ):
     ''' Line separator detection from bytes. '''
-    parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Test detection of different line separators
     cr_bytes = b'line1\rline2\rline3'
@@ -48,44 +48,44 @@ def test_010_line_separators_detection( ):
     no_terminator_bytes = b'line1line2line3'
 
     assert (
-        parts.LineSeparators.detect_bytes( cr_bytes )
-        == parts.LineSeparators.CR )
+        detextive.LineSeparators.detect_bytes( cr_bytes )
+        == detextive.LineSeparators.CR )
     assert (
-        parts.LineSeparators.detect_bytes( crlf_bytes )
-        == parts.LineSeparators.CRLF )
+        detextive.LineSeparators.detect_bytes( crlf_bytes )
+        == detextive.LineSeparators.CRLF )
     assert (
-        parts.LineSeparators.detect_bytes( lf_bytes )
-        == parts.LineSeparators.LF )
+        detextive.LineSeparators.detect_bytes( lf_bytes )
+        == detextive.LineSeparators.LF )
 
     # With mixed bytes, it detects the first encountered line separator
     assert (
-        parts.LineSeparators.detect_bytes( mixed_bytes )
-        == parts.LineSeparators.CR )
+        detextive.LineSeparators.detect_bytes( mixed_bytes )
+        == detextive.LineSeparators.CR )
 
     # Double CR case
     assert (
-        parts.LineSeparators.detect_bytes( double_cr_bytes )
-        == parts.LineSeparators.CR )
+        detextive.LineSeparators.detect_bytes( double_cr_bytes )
+        == detextive.LineSeparators.CR )
 
     # Empty bytes and bytes without terminators
-    assert parts.LineSeparators.detect_bytes( empty_bytes ) is None
-    assert parts.LineSeparators.detect_bytes( no_terminator_bytes ) is None
+    assert detextive.LineSeparators.detect_bytes( empty_bytes ) is None
+    assert detextive.LineSeparators.detect_bytes( no_terminator_bytes ) is None
 
 
 def test_020_line_separators_normalization( ):
     ''' Line separator normalization methods. '''
-    parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Test universal normalization
     mixed_content = "line1\rline2\r\nline3\n"
-    normalized = parts.LineSeparators.normalize_universal( mixed_content )
+    normalized = detextive.LineSeparators.normalize_universal( mixed_content )
     assert normalized == "line1\nline2\nline3\n"
 
     # Test specific separator nativization and normalization
     cr_content = "line1\rline2\rline3"
-    lf_sep = parts.LineSeparators.LF
-    cr_sep = parts.LineSeparators.CR
-    crlf_sep = parts.LineSeparators.CRLF
+    lf_sep = detextive.LineSeparators.LF
+    cr_sep = detextive.LineSeparators.CR
+    crlf_sep = detextive.LineSeparators.CRLF
 
     # Test LF nativization (no change)
     assert lf_sep.nativize( cr_content ) == cr_content
@@ -104,6 +104,7 @@ def test_020_line_separators_normalization( ):
 def test_100_part_immutability( ):
     ''' Part class immutability. '''
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     import pytest
     from frigid.exceptions import AttributeImmutability
 
@@ -112,7 +113,7 @@ def test_100_part_immutability( ):
         location = 'test.txt',
         mimetype = 'text/plain',
         charset = 'utf-8',
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = 'test content'
     )
 
@@ -124,7 +125,7 @@ def test_100_part_immutability( ):
     with pytest.raises( AttributeImmutability ):
         part.charset = 'ascii'
     with pytest.raises( AttributeImmutability ):
-        part.linesep = parts.LineSeparators.CRLF
+        part.linesep = detextive.LineSeparators.CRLF
     with pytest.raises( AttributeImmutability ):
         part.content = 'new content'
 
@@ -132,13 +133,14 @@ def test_100_part_immutability( ):
 def test_110_part_creation( ):
     ''' Creating Part instances with different parameters. '''
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Test with various valid inputs
     part_1 = parts.Part(
         location = '/path/to/file.txt',
         mimetype = 'text/plain',
         charset = 'utf-8',
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = 'Sample text content'
     )
 
@@ -146,7 +148,7 @@ def test_110_part_creation( ):
     assert part_1.location == '/path/to/file.txt'
     assert part_1.mimetype == 'text/plain'
     assert part_1.charset == 'utf-8'
-    assert part_1.linesep == parts.LineSeparators.LF
+    assert part_1.linesep == detextive.LineSeparators.LF
     assert part_1.content == 'Sample text content'
 
     # Test with URL location
@@ -154,11 +156,11 @@ def test_110_part_creation( ):
         location = 'https://example.com/data.txt',
         mimetype = 'text/csv',
         charset = 'ascii',
-        linesep = parts.LineSeparators.CRLF,
+        linesep = detextive.LineSeparators.CRLF,
         content = 'header,value\n1,2\n'
     )
 
     assert part_2.location == 'https://example.com/data.txt'
     assert part_2.mimetype == 'text/csv'
     assert part_2.charset == 'ascii'
-    assert part_2.linesep == parts.LineSeparators.CRLF
+    assert part_2.linesep == detextive.LineSeparators.CRLF

--- a/tests/test_000_mimeogram/test_200_parsers.py
+++ b/tests/test_000_mimeogram/test_200_parsers.py
@@ -48,6 +48,7 @@ def test_000_basic_parse( ):
     ''' Simple valid mimeogram. '''
     parsers = cache_import_module( f"{PACKAGE_NAME}.parsers" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Create a simple test mimeogram
     mimeogram_text = _create_sample_mimeogram()
@@ -61,7 +62,7 @@ def test_000_basic_parse( ):
     assert first_part.location == 'test.txt'
     assert first_part.mimetype == 'text/plain'
     assert first_part.charset == 'utf-8'
-    assert first_part.linesep == parts.LineSeparators.LF
+    assert first_part.linesep == detextive.LineSeparators.LF
     assert first_part.content == 'Sample content'
 
 
@@ -95,7 +96,7 @@ def test_010_parse_multiple_parts( ):
 def test_020_parse_part_details( ):
     ''' Details of a single part. '''
     parsers = cache_import_module( f"{PACKAGE_NAME}.parsers" )
-    parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Create mimeogram with detailed headers
     mimeogram_text = (
@@ -113,7 +114,7 @@ def test_020_parse_part_details( ):
     assert first_part.location == 'detailed.txt'
     assert first_part.mimetype == 'application/json'
     assert first_part.charset == 'utf-8'
-    assert first_part.linesep == parts.LineSeparators.CRLF
+    assert first_part.linesep == detextive.LineSeparators.CRLF
     assert first_part.content == '{"key": "value"}'
 
 
@@ -204,12 +205,12 @@ def test_070_unicode_content( ):
 def test_080_line_separator_variations( ):
     ''' Mimeograms with different line separators. '''
     parsers = cache_import_module( f"{PACKAGE_NAME}.parsers" )
-    parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     # Create test cases for LF and CRLF line separators
     separators = [
-        ('\n', parts.LineSeparators.LF),
-        ('\r\n', parts.LineSeparators.CRLF)
+        ('\n', detextive.LineSeparators.LF),
+        ('\r\n', detextive.LineSeparators.CRLF)
     ]
 
     for sep, expected_type in separators:

--- a/tests/test_000_mimeogram/test_210_formatters.py
+++ b/tests/test_000_mimeogram/test_210_formatters.py
@@ -35,11 +35,12 @@ def _create_sample_part(
     content = 'Sample content'
 ):
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     return parts.Part(
         location = location,
         mimetype = mimetype,
         charset = charset,
-        linesep = parts.LineSeparators[ linesep ],
+        linesep = detextive.LineSeparators[ linesep ],
         content = content
     )
 

--- a/tests/test_000_mimeogram/test_320_differences.py
+++ b/tests/test_000_mimeogram/test_320_differences.py
@@ -61,6 +61,7 @@ async def test_100_select_segments_empty_revision( provide_tempdir ):
     ''' Original content remains unchanged when revision matches. '''
     differences = cache_import_module( f"{PACKAGE_NAME}.differences" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     current = "test content"
@@ -72,7 +73,7 @@ async def test_100_select_segments_empty_revision( provide_tempdir ):
             location = str( test_path ),
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = current )
         target = parts.Target(
             part = part,
@@ -92,6 +93,7 @@ async def test_110_select_segments_with_changes( provide_tempdir ):
     ''' Change acceptance preserves modified content. '''
     differences = cache_import_module( f"{PACKAGE_NAME}.differences" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     current = "line 1\nline 2\nline 3"
@@ -104,7 +106,7 @@ async def test_110_select_segments_with_changes( provide_tempdir ):
             location = str( test_path ),
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = current )
         target = parts.Target(
             part = part,
@@ -127,6 +129,7 @@ async def test_120_select_segments_reject_changes( provide_tempdir ):
     ''' Change rejection maintains original content. '''
     differences = cache_import_module( f"{PACKAGE_NAME}.differences" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     current = "line 1\nline 2\nline 3"
@@ -139,7 +142,7 @@ async def test_120_select_segments_reject_changes( provide_tempdir ):
             location = str( test_path ),
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = current )
         target = parts.Target(
             part = part,
@@ -164,6 +167,7 @@ async def test_130_select_segments_multiple_changes(
     ''' Multiple changes handled correctly. '''
     differences = cache_import_module( f"{PACKAGE_NAME}.differences" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     current = "line 1\nline 2\nline 3\nline 4"
@@ -176,7 +180,7 @@ async def test_130_select_segments_multiple_changes(
             location = str( test_path ),
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = current )
         target = parts.Target(
             part = part,
@@ -270,6 +274,7 @@ async def test_140_select_segments_handles_errors( provide_tempdir ):
     ''' Processing errors preserve original revision. '''
     differences = cache_import_module( f"{PACKAGE_NAME}.differences" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     current = "line 1\nline 2\nline 3"
@@ -289,7 +294,7 @@ async def test_140_select_segments_handles_errors( provide_tempdir ):
             location = str( test_path ),
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = current )
         target = parts.Target(
             part = part,

--- a/tests/test_000_mimeogram/test_330_interactions.py
+++ b/tests/test_000_mimeogram/test_330_interactions.py
@@ -30,12 +30,13 @@ def test_100_calculate_differences( ):
     ''' Difference calculation handles various content cases. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     part = parts.Part(
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "" )
 
     # Empty both
@@ -58,6 +59,7 @@ async def test_200_interact_simple_apply( provide_tempdir ):
     ''' Apply resolution returned for unprotected content. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     async def mock_noop( *args ): pass
@@ -70,7 +72,7 @@ async def test_200_interact_simple_apply( provide_tempdir ):
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "test content" )
     target = parts.Target(
         part = part,
@@ -98,6 +100,7 @@ async def test_210_interact_simple_ignore( provide_tempdir ):
     ''' Ignore resolution returned for protected content. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     async def mock_noop( *args ): pass
@@ -110,7 +113,7 @@ async def test_210_interact_simple_ignore( provide_tempdir ):
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "test content" )
     target = parts.Target(
         part = part,
@@ -138,6 +141,7 @@ async def test_220_interact_edit_then_apply( provide_tempdir ):
     ''' Content editing followed by apply resolution. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     choices = iter( [ 'e', 'a' ] )
@@ -151,7 +155,7 @@ async def test_220_interact_edit_then_apply( provide_tempdir ):
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "test content" )
     target = parts.Target(
         part = part,
@@ -179,6 +183,7 @@ async def test_230_interact_displays_content( provide_tempdir ):
     ''' Content display operations invoked appropriately. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     content_displayed = False
@@ -202,7 +207,7 @@ async def test_230_interact_displays_content( provide_tempdir ):
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "test content" )
     target = parts.Target(
         part = part,
@@ -231,6 +236,7 @@ async def test_240_interact_select_segments( provide_tempdir ):
     ''' Segment selection updates content. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     choices = iter( [ 's', 'a' ] )
@@ -249,7 +255,7 @@ async def test_240_interact_select_segments( provide_tempdir ):
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "test content" )
     target = parts.Target(
         part = part,
@@ -278,6 +284,7 @@ async def test_300_interact_protected_flow( provide_tempdir ):
     ''' Protection removal enables edits. '''
     interactions = cache_import_module( f"{PACKAGE_NAME}.interactions" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     fsprotect = cache_import_module( f"{PACKAGE_NAME}.fsprotect" )
 
     choices = iter( [ 'e', 'p', 'e', 'a' ] )
@@ -291,7 +298,7 @@ async def test_300_interact_protected_flow( provide_tempdir ):
         location = "test.txt",
         mimetype = "text/plain",
         charset = "utf-8",
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = "test content" )
     target = parts.Target(
         part = part,

--- a/tests/test_000_mimeogram/test_500_acquirers.py
+++ b/tests/test_000_mimeogram/test_500_acquirers.py
@@ -510,7 +510,7 @@ async def test_540_strict_mode_multiple_failures(
 
         assert len( excinfo.value.exceptions ) == 2
         for exc in excinfo.value.exceptions:
-            # ContentDecodeFailure when Detextive detects charset but can't decode
+            # ContentDecodeFailure or TextualMimetypeInvalidity expected
             assert isinstance(
                 exc,
                 ( exceptions.TextualMimetypeInvalidity,
@@ -572,7 +572,7 @@ async def test_550_strict_mode_http_failures( provide_auxdata, httpx_mock ):
         for exc in excinfo.value.exceptions }
 
     assert len( exceptions_by_type ) == 2
-    # Detextive may raise ContentDecodeFailure instead of TextualMimetypeInvalidity
+    # Detextive may raise ContentDecodeFailure or TextualMimetypeInvalidity
     assert (
         'TextualMimetypeInvalidity' in exceptions_by_type
         or 'ContentDecodeFailure' in exceptions_by_type )
@@ -699,7 +699,7 @@ async def test_620_http_nontextual_mimetype( provide_auxdata, httpx_mock ):
         await acquirers.acquire( provide_auxdata, [ test_url ] )
 
     assert len( excinfo.value.exceptions ) == 1
-    # Detextive may raise ContentDecodeFailure instead of TextualMimetypeInvalidity
+    # Detextive may raise ContentDecodeFailure or TextualMimetypeInvalidity
     assert isinstance(
         excinfo.value.exceptions[ 0 ],
         ( exceptions.TextualMimetypeInvalidity,

--- a/tests/test_000_mimeogram/test_500_acquirers.py
+++ b/tests/test_000_mimeogram/test_500_acquirers.py
@@ -127,7 +127,7 @@ async def test_120_acquire_recursive_directory(
 async def test_200_detect_line_endings( provide_tempdir, provide_auxdata ):
     ''' Successfully detects and normalizes different line endings. '''
     acquirers = cache_import_module( f"{PACKAGE_NAME}.acquirers" )
-    parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     test_files = {
         "unix.txt": "line1\nline2\n",          # LF
         "windows.txt": "line1\r\nline2\r\n",   # CRLF
@@ -140,7 +140,7 @@ async def test_200_detect_line_endings( provide_tempdir, provide_auxdata ):
         assert len( results ) == 2
         lineseps = { part.linesep for part in results }
         assert lineseps == {
-            parts.LineSeparators.LF, parts.LineSeparators.CRLF }
+            detextive.LineSeparators.LF, detextive.LineSeparators.CRLF }
         # All content should be normalized to LF
         for part in results:
             assert part.content.count( '\r\n' ) == 0

--- a/tests/test_000_mimeogram/test_510_updaters.py
+++ b/tests/test_000_mimeogram/test_510_updaters.py
@@ -110,6 +110,7 @@ async def test_100_update_simple_file(
     ''' Basic file update works correctly in Silent mode. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     files = { 'test.txt': 'original content' }
     with create_test_files( provide_tempdir, files ):
@@ -117,7 +118,7 @@ async def test_100_update_simple_file(
             location = 'test.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'updated content'
         )
 
@@ -141,12 +142,13 @@ async def test_110_update_skips_mimeogram_protocol(
     ''' Update should skip parts with mimeogram:// protocol. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     test_part = parts.Part(
         location = 'mimeogram://message',
         mimetype = 'text/plain',
         charset = 'utf-8',
-        linesep = parts.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = 'test content'
     )
 
@@ -169,6 +171,7 @@ async def test_120_update_respects_protection(
     ''' Update respects filesystem protections (active = True => skip). '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     files = { 'test.txt': 'original content' }
     with create_test_files( provide_tempdir, files ):
@@ -176,7 +179,7 @@ async def test_120_update_respects_protection(
             location = 'test.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'updated content'
         )
 
@@ -201,6 +204,7 @@ async def test_130_update_override_protections(
     ''' Update can override protections if disable-protections=true. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     files = { 'test.txt': 'original content' }
     with create_test_files( provide_tempdir, files ):
@@ -208,7 +212,7 @@ async def test_130_update_override_protections(
             location = 'test.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'updated content'
         )
 
@@ -237,6 +241,7 @@ async def test_140_update_respects_interactor( provide_tempdir ):
     ''' Update uses provided interactor for changes in Partitive mode. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     files = { 'test.txt': 'original content' }
     with create_test_files( provide_tempdir, files ):
@@ -244,7 +249,7 @@ async def test_140_update_respects_interactor( provide_tempdir ):
             location = 'test.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'test content'
         )
 
@@ -286,6 +291,7 @@ async def test_160_partitive_ignore_mode( provide_tempdir ):
     ''' Partitive-mode Ignore action should not overwrite file. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     files = { 'test.txt': 'original content' }
     with create_test_files( provide_tempdir, files ):
@@ -293,7 +299,7 @@ async def test_160_partitive_ignore_mode( provide_tempdir ):
             location = 'test.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'new content'
         )
 
@@ -322,6 +328,7 @@ async def test_170_queue_and_reverter_rollback_on_error(
     ''' Reverter restores files if error occurs on subsequent updates. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts_mod = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
     exceptions = cache_import_module( f"{PACKAGE_NAME}.exceptions" )
 
     files = {
@@ -333,14 +340,14 @@ async def test_170_queue_and_reverter_rollback_on_error(
             location = 'file1.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts_mod.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'file1 updated'
         )
         part2 = parts_mod.Part(
             location = 'file2.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts_mod.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = 'file2 updated'
         )
 
@@ -377,6 +384,7 @@ async def test_180_line_endings_preserved( provide_tempdir ):
     ''' CRLF line separators are preserved in the updated file. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
     parts_mod = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     files = { 'test_windows.txt': 'line1\r\nline2\r\n' }
     with create_test_files( provide_tempdir, files ):
@@ -384,7 +392,7 @@ async def test_180_line_endings_preserved( provide_tempdir ):
             location = 'test_windows.txt',
             mimetype = 'text/plain',
             charset = 'utf-8',
-            linesep = parts_mod.LineSeparators.CRLF,
+            linesep = detextive.LineSeparators.CRLF,
             content = 'line1\r\nline2\r\nline3\r\n'
         )
 
@@ -404,6 +412,7 @@ async def test_180_line_endings_preserved( provide_tempdir ):
 async def test_190_reverter_direct_coverage( provide_tempdir ):
     ''' Direct Reverter calls for saving non-existent and existing files. '''
     updaters = cache_import_module( f"{PACKAGE_NAME}.updaters" )
+    detextive = cache_import_module( 'detextive' )
     parts_mod = cache_import_module( f"{PACKAGE_NAME}.parts" )
 
     reverter = updaters.Reverter( )
@@ -413,7 +422,7 @@ async def test_190_reverter_direct_coverage( provide_tempdir ):
         location = str( nonexistent_path ),
         mimetype = 'text/plain',
         charset = 'utf-8',
-        linesep = parts_mod.LineSeparators.LF,
+        linesep = detextive.LineSeparators.LF,
         content = ''
     )
     # 1) Non-existent => skip saving

--- a/tests/test_000_mimeogram/test_610_apply.py
+++ b/tests/test_000_mimeogram/test_610_apply.py
@@ -202,6 +202,7 @@ async def test_400_apply_success( ):
     ''' apply function handles successful case correctly. '''
     apply = cache_import_module( f"{PACKAGE_NAME}.apply" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     test_content = "test mimeogram"
     test_parts = [
@@ -209,7 +210,7 @@ async def test_400_apply_success( ):
             location = "test.txt",
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = "test content" ) ]
 
     async def mock_updater(
@@ -277,6 +278,7 @@ async def test_430_apply_update_failure( ):
     ''' apply function handles update failures appropriately. '''
     apply = cache_import_module( f"{PACKAGE_NAME}.apply" )
     parts = cache_import_module( f"{PACKAGE_NAME}.parts" )
+    detextive = cache_import_module( 'detextive' )
 
     test_content = "test mimeogram"
     test_parts = [
@@ -284,7 +286,7 @@ async def test_430_apply_update_failure( ):
             location = "test.txt",
             mimetype = "text/plain",
             charset = "utf-8",
-            linesep = parts.LineSeparators.LF,
+            linesep = detextive.LineSeparators.LF,
             content = "test content" ) ]
 
     async def failing_updater( auxdata, parts, **kwargs ):


### PR DESCRIPTION
Replace internal MIME type detection, charset encoding detection, and bytes-to-string decoding with Detextive 2.0 API calls. This removes dependencies on chardet and puremagic packages and consolidates text detection functionality.

Major changes:
* Update pyproject.toml to use detextive~=2.0
* Remove chardet and puremagic dependencies
* Replace parts.LineSeparators with detextive.LineSeparators
* Replace _detect_charset() with detextive.infer_charset()
* Replace _detect_mimetype_and_charset() with detextive.infer_mimetype_charset()
* Replace manual content.decode() with detextive.decode()
* Remove internal detection functions from acquirers.py
* Update tests to accommodate Detextive's behavioral differences

Test updates:
* Accept normalized charset names (e.g., 'iso8859-9' vs 'iso-8859-9')
* Accept both TextualMimetypeInvalidity and ContentDecodeFailure exceptions
* Update binary file tests to use PE/DMG headers that Detextive rejects
* Accept empty files as valid text (Detextive behavior)
* Document UTF-16-LE false positive detection in .auxiliary/notes/detextive-bugs.md